### PR TITLE
Loop in IE

### DIFF
--- a/src/BackToTop.vue
+++ b/src/BackToTop.vue
@@ -40,7 +40,7 @@ export default {
       let currentScroll = document.documentElement.scrollTop || document.body.scrollTop
       if (currentScroll > 0) {
         window.requestAnimationFrame(window.smoothscroll)
-        window.scrollTo(0, currentScroll - (currentScroll / 5))
+        window.scrollTo(0, Math.floor(currentScroll - (currentScroll / 5)))
       }
     }
 


### PR DESCRIPTION
Loop will happen when browser round a number upward to its nearest integer.
e.g. 
if currentScroll = 2
then (currentScroll - (currentScroll / 5)) = 1.6
In chrome it will rounded to 1, but in ie11 it will be rounded to 2
So on next step currentScroll will equal 2 - it's loop

Could you please fix asap