### PR TITLE
Change vue dep to be lower bound

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue-backtotop",
   "description": "A Back-to-top component for Vue.js",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "author": "Caio Fernandes <caio_fsouza@hotmail.com>",
   "main": "src/main.js",
   "scripts": {
@@ -9,7 +9,7 @@
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules"
   },
   "dependencies": {
-    "vue": "2.3.3"
+    "vue": "^2.3.3"
   },
   "devDependencies": {
     "babel-core": "^6.0.0",


### PR DESCRIPTION
Previously it was fixed version, pulling in duplicate Vue into the user project potentially.

Noticed by running the `webpack-bundle-analyzer` plugin (see https://dev.to/m9hmood/reduce-vue-js-application-size-kfl), then did `npm ls vue`, which printed

```
$ npm ls vue                                                                                                                                               
my-ui
├── vue@2.6.9
├─┬ vue-backtotop@1.6.1                                                                                                                                                                                              
  └── vue@2.3.3                                                                                                                                                                                                    ```
Thanks for the component btw!